### PR TITLE
Add pipfs directory in nfs.conf to support nfs-utils 1:2.6.1-1ubuntu1.2

### DIFF
--- a/templates/default/nfs.conf.erb
+++ b/templates/default/nfs.conf.erb
@@ -3,6 +3,9 @@
 #
 # This is a general configuration for the
 # NFS daemons and tools
+[general]
+pipefs-directory=<%= node['nfs']['idmap']['pipefs_directory'] %>
+
 [gssd]
 use-gss-proxy=1
 


### PR DESCRIPTION
When using nfs-utils `1:2.6.1-1ubuntu1.2`, for example on Ubuntu22, the installation of `nfs` cookbook fails with:
```
---- Begin output of ["/usr/bin/systemctl", "--system", "start", "nfs-idmapd.service"] ----
       STDOUT: 
       STDERR: Job for nfs-idmapd.service failed because the control process exited with error code.
       See "systemctl status nfs-idmapd.service" and "journalctl -xeu nfs-idmapd.service" for details.
```

In the log files you can find the reason:
```
ubuntu@ip-10-0-0-62:~$ systemctl status nfs-idmapd.service
× nfs-idmapd.service - NFSv4 ID-name mapping service
     Loaded: loaded (/lib/systemd/system/nfs-idmapd.service; static)
     Active: failed (Result: exit-code) since Fri 2023-08-11 10:23:08 UTC; 3min 58s ago
    Process: 2960 ExecStart=/usr/sbin/rpc.idmapd (code=exited, status=1/FAILURE)
...
Unable to inotify_add_watch(/var/lib/nfs/rpc_pipefs//nfs): No such file or directory
```

By searching online you can see that  this is due to a known bug in `nfs-utils 1:2.6.1-1ubuntu1.2`. The bug has been fixed but not yet available:
https://bugs.launchpad.net/ubuntu/+source/nfs-utils/+bug/1971935

To workaround this issue is enough to configure the `pipefs-directory` parameter in the `[general]` section of the `nfs.conf` file:

```
[general]
pipefs-directory=/run/rpc_pipefs/
```

This section is already present and correctly configured in the default `nfs.conf` file, but the `nfs` cookbook is removing it, causing the issue to appear:
```
 Recipe: nfs::_common
             * apt_package[nfs-common] action install[2023-08-11T10:22:55+00:00] INFO: Processing apt_package[nfs-common] action install (nfs::_common line 22)
       [2023-08-11T10:23:02+00:00] INFO: apt_package[nfs-common] installed nfs-common at 1:2.6.1-1ubuntu1.2
       
        - install version 1:2.6.1-1ubuntu1.2 of package nfs-common
             * apt_package[rpcbind] action install[2023-08-11T10:23:02+00:00] INFO: Processing apt_package[rpcbind] action install (nfs::_common line 22)
        (up to date)
             * directory[/etc] action create[2023-08-11T10:23:02+00:00] INFO: Processing directory[/etc] action create (nfs::_common line 26)
        (skipped due to only_if)
             * template[/etc/nfs.conf] action create[2023-08-11T10:23:02+00:00] INFO: Processing template[/etc/nfs.conf] action create (nfs::_common line 36)
       [2023-08-11T10:23:02+00:00] INFO: template[/etc/nfs.conf] backed up to /tmp/kitchen/backup/etc/nfs.conf.chef-20230811102302.181807
       [2023-08-11T10:23:02+00:00] INFO: template[/etc/nfs.conf] updated file contents /etc/nfs.conf
       
        - update content in file /etc/nfs.conf from 802c52 to 769354
        --- /etc/nfs.conf       2022-10-20 14:50:13.000000000 +0000
        +++ /etc/.chef-nfs20230811-1570-ufazs0.conf     2023-08-11 10:23:02.166567804 +0000
        @@ -1,87 +1,24 @@
        +# Generated by Chef for ip-10-0-0-62.eu-west-1.compute.internal# Local modifications will be overwritten.
         #
         # This is a general configuration for the
         # NFS daemons and tools
        -#
        -[general]
        -pipefs-directory=/run/rpc_pipefs
        -#
...
``` 

With this patch I'm just avoiding to remove the existing value. This permits `nfs` cookbook to work even when using the bugged version of `nfs-utils` package.

### Tests
* Tested on Ubuntu22


### References
* https://github.com/sous-chefs/nfs/issues/93
* https://bugs.launchpad.net/ubuntu/+source/nfs-utils/+bug/1971935